### PR TITLE
:sparkles: feat: 리뷰 cr 구현

### DIFF
--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/controller/ReviewController.java
@@ -1,0 +1,76 @@
+package com.microservices.demo.practiceserver.domain.review.controller;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.microservices.demo.practiceserver.domain.member.entity.Member;
+import com.microservices.demo.practiceserver.domain.product.entity.mapping.MemberProduct;
+import com.microservices.demo.practiceserver.domain.review.dto.MemberDTO;
+import com.microservices.demo.practiceserver.domain.review.dto.MemberProductDTO;
+import com.microservices.demo.practiceserver.domain.review.dto.ReviewRequestDTO;
+import com.microservices.demo.practiceserver.domain.review.dto.ReviewResponseDTO;
+import com.microservices.demo.practiceserver.domain.review.entity.Review;
+import com.microservices.demo.practiceserver.domain.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@RestController
+@RequiredArgsConstructor
+public class ReviewController {
+    @Autowired
+    private final ReviewService reviewService;
+
+    @PostMapping("/reviews")
+    public ResponseEntity<ReviewResponseDTO.CreateReviewResponseDTO> createReview(@RequestBody ReviewRequestDTO.CreateReviewDTO request) {
+
+        Review review = reviewService.createReview(request);
+        ReviewResponseDTO.CreateReviewResponseDTO response = ReviewResponseDTO.CreateReviewResponseDTO.builder()
+                .id(review.getId())
+                .score(review.getScore())
+                .member(toMemberDTO(review.getMember()))
+                .memberProduct(toMemberProductDTO(review.getMemberProduct()))
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+    public MemberDTO toMemberDTO(Member member){
+        return new MemberDTO(member.getId(), member.getEmail(), member.getNickname(), member.getPassword());
+    }
+    public MemberProductDTO toMemberProductDTO(MemberProduct memberProduct){
+        return new MemberProductDTO(memberProduct.getId(), memberProduct.getId(), memberProduct.getId(), memberProduct.getSize());
+    }
+    @GetMapping("/reviewList")
+    public List<ReviewResponseDTO.ReviewListResponseDTO> getReviewList() {
+        List<Review> reviewList = reviewService.getReviewList();
+
+        List<ReviewResponseDTO.ReviewListResponseDTO> dtos = reviewList.stream()
+                .map(review -> new ReviewResponseDTO.ReviewListResponseDTO(review.getId(),
+                        review.getScore(),
+                        review.getContent(),
+                        toMemberDTO(review.getMember()),
+                        toMemberProductDTO(review.getMemberProduct())
+                        )).collect(Collectors.toList());
+
+        return dtos;
+    }
+
+    @JsonIgnoreProperties
+    @GetMapping("/reviews/{reviewID}")
+    public ReviewResponseDTO.ReviewDetailResponseDTO getReview(@PathVariable("reviewID") Long reviewID) {
+        Review review = reviewService.getReview(reviewID);
+        ReviewResponseDTO.ReviewDetailResponseDTO response = ReviewResponseDTO.ReviewDetailResponseDTO.builder()
+                .id(review.getId())
+                .score(review.getScore())
+                .member(toMemberDTO(review.getMember()))
+                .memberProduct(toMemberProductDTO(review.getMemberProduct()))
+                .build();
+
+        return response;
+    }
+
+
+}

--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/controller/ReviewController.java
@@ -31,19 +31,22 @@ public class ReviewController {
         ReviewResponseDTO.CreateReviewResponseDTO response = ReviewResponseDTO.CreateReviewResponseDTO.builder()
                 .id(review.getId())
                 .score(review.getScore())
-                .member(toMemberDTO(review.getMember()))
-                .memberProduct(toMemberProductDTO(review.getMemberProduct()))
+                .content(review.getContent())
+                .member(null)
+                .memberProduct(null)
+//                .member(toMemberDTO(review.getMember()))
+//                .memberProduct(toMemberProductDTO(review.getMemberProduct()))
                 .build();
 
         return ResponseEntity.ok(response);
     }
-    public MemberDTO toMemberDTO(Member member){
+    private MemberDTO toMemberDTO(Member member){
         return new MemberDTO(member.getId(), member.getEmail(), member.getNickname(), member.getPassword());
     }
     public MemberProductDTO toMemberProductDTO(MemberProduct memberProduct){
         return new MemberProductDTO(memberProduct.getId(), memberProduct.getId(), memberProduct.getId(), memberProduct.getSize());
     }
-    @GetMapping("/reviewList")
+    @GetMapping("/reviewLists")
     public List<ReviewResponseDTO.ReviewListResponseDTO> getReviewList() {
         List<Review> reviewList = reviewService.getReviewList();
 

--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/dto/MemberDTO.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/dto/MemberDTO.java
@@ -1,0 +1,20 @@
+package com.microservices.demo.practiceserver.domain.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MemberDTO{
+    private final Long member_id;
+    private final String email;
+    private final String nickname;
+    private final String password;
+
+    public MemberDTO(Long member_id, String email, String nickname, String password) {
+        this.member_id = member_id;
+        this.email = email;
+        this.nickname = nickname;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/dto/MemberProductDTO.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/dto/MemberProductDTO.java
@@ -1,0 +1,23 @@
+package com.microservices.demo.practiceserver.domain.review.dto;
+
+import com.microservices.demo.practiceserver.domain.member.entity.Member;
+import com.microservices.demo.practiceserver.domain.product.entity.Product;
+import com.microservices.demo.practiceserver.domain.product.entity.enums.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+@Data
+@AllArgsConstructor
+@Builder
+public class MemberProductDTO{
+    private final Long memberId;
+    private final Long memberProductId;
+    private final Long productId;
+    private final Size size;
+
+
+
+
+
+}

--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/dto/ReviewRequestDTO.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/dto/ReviewRequestDTO.java
@@ -1,0 +1,31 @@
+package com.microservices.demo.practiceserver.domain.review.dto;
+
+import com.microservices.demo.practiceserver.domain.member.entity.Member;
+import com.microservices.demo.practiceserver.domain.product.entity.mapping.MemberProduct;
+import lombok.*;
+
+
+public class ReviewRequestDTO {
+
+
+
+    @Data
+    @Getter
+    public static class CreateReviewDTO{
+
+        private Double score;
+        private String content;
+        private Member member;
+        private MemberProduct memberProduct;
+
+
+
+    }
+    @Getter
+    public static class ReadReviewDTO{
+        private Double score;
+        private String content;
+        private Member member;
+        private MemberProduct memberProduct;
+    }
+}

--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/dto/ReviewRequestDTO.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/dto/ReviewRequestDTO.java
@@ -9,14 +9,14 @@ public class ReviewRequestDTO {
 
 
 
-    @Data
+
     @Getter
     public static class CreateReviewDTO{
 
         private Double score;
         private String content;
-        private Member member;
-        private MemberProduct memberProduct;
+        private Long memberId;
+        private Long memberProductId;
 
 
 

--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/dto/ReviewResponseDTO.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@AllArgsConstructor
 public class ReviewResponseDTO {
 
 

--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/dto/ReviewResponseDTO.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/dto/ReviewResponseDTO.java
@@ -1,0 +1,55 @@
+package com.microservices.demo.practiceserver.domain.review.dto;
+
+import com.microservices.demo.practiceserver.domain.member.entity.Member;
+import com.microservices.demo.practiceserver.domain.product.entity.mapping.MemberProduct;
+import com.microservices.demo.practiceserver.domain.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+public class ReviewResponseDTO {
+
+
+
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class CreateReviewResponseDTO{
+        private final Long id;
+        private final Double score;
+        private final String content;
+        private final MemberDTO member;
+        private final MemberProductDTO memberProduct;
+    }
+
+
+
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class ReviewListResponseDTO{
+        private final Long id;
+        private final Double score;
+        private final String content;
+        private final MemberDTO member;
+        private final MemberProductDTO memberProduct;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class ReviewDetailResponseDTO{
+        private final Long id;
+        private final Double score;
+        private final String content;
+        private final MemberDTO member;
+        private final MemberProductDTO memberProduct;
+
+    }
+}

--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/entity/Review.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/entity/Review.java
@@ -26,10 +26,10 @@ public class Review {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_product_id", nullable = false, unique = true)
+    @JoinColumn(name = "member_product_id", unique = true)
     private MemberProduct memberProduct;
 }

--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,13 @@
+package com.microservices.demo.practiceserver.domain.review.repository;
+
+import com.microservices.demo.practiceserver.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review,Long> {
+
+
+}

--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/service/ReviewService.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/service/ReviewService.java
@@ -1,0 +1,17 @@
+package com.microservices.demo.practiceserver.domain.review.service;
+
+import com.microservices.demo.practiceserver.domain.review.dto.ReviewRequestDTO;
+import com.microservices.demo.practiceserver.domain.review.entity.Review;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public interface ReviewService {
+
+    Review createReview(ReviewRequestDTO.CreateReviewDTO request);
+
+    List<Review> getReviewList();
+
+    Review getReview(Long reviewId);
+}

--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/service/ReviewServiceImpl.java
@@ -1,0 +1,51 @@
+package com.microservices.demo.practiceserver.domain.review.service;
+
+import com.microservices.demo.practiceserver.domain.member.entity.Member;
+import com.microservices.demo.practiceserver.domain.review.dto.MemberDTO;
+import com.microservices.demo.practiceserver.domain.review.dto.ReviewRequestDTO;
+import com.microservices.demo.practiceserver.domain.review.dto.ReviewResponseDTO;
+import com.microservices.demo.practiceserver.domain.review.entity.Review;
+import com.microservices.demo.practiceserver.domain.review.repository.ReviewRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ReviewServiceImpl implements ReviewService{
+    @Autowired
+    private final ReviewRepository reviewRepository;
+
+    public ReviewServiceImpl(ReviewRepository reviewRepository) {
+        this.reviewRepository = reviewRepository;
+    }
+
+    @Override
+    public Review createReview(ReviewRequestDTO.CreateReviewDTO request){
+
+
+        Review review = Review.builder()
+                .score(request.getScore())
+                .content(request.getContent())
+                .member(request.getMember())
+                .memberProduct(request.getMemberProduct())
+                .build();
+
+
+        reviewRepository.save(review);
+        return null;
+    }
+
+
+    @Override
+    public List<Review> getReviewList(){
+        return reviewRepository.findAll();
+
+    }
+
+    @Override
+    public Review getReview(Long reviewId){
+        return reviewRepository.findById(reviewId)
+                .orElseThrow(()->new RuntimeException("리뷰를 찾지 못했습니다"));
+    }
+}

--- a/src/main/java/com/microservices/demo/practiceserver/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/microservices/demo/practiceserver/domain/review/service/ReviewServiceImpl.java
@@ -6,19 +6,18 @@ import com.microservices.demo.practiceserver.domain.review.dto.ReviewRequestDTO;
 import com.microservices.demo.practiceserver.domain.review.dto.ReviewResponseDTO;
 import com.microservices.demo.practiceserver.domain.review.entity.Review;
 import com.microservices.demo.practiceserver.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class ReviewServiceImpl implements ReviewService{
     @Autowired
     private final ReviewRepository reviewRepository;
 
-    public ReviewServiceImpl(ReviewRepository reviewRepository) {
-        this.reviewRepository = reviewRepository;
-    }
 
     @Override
     public Review createReview(ReviewRequestDTO.CreateReviewDTO request){
@@ -27,13 +26,13 @@ public class ReviewServiceImpl implements ReviewService{
         Review review = Review.builder()
                 .score(request.getScore())
                 .content(request.getContent())
-                .member(request.getMember())
-                .memberProduct(request.getMemberProduct())
+                .member(null)
+                .memberProduct(null)
                 .build();
 
 
-        reviewRepository.save(review);
-        return null;
+
+        return reviewRepository.save(review);
     }
 
 


### PR DESCRIPTION
## PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 관련 이슈 링크
Close #6

## 📌 개요
- 리뷰 Create, Read(CR) 기능을 구현하였습니다.
- Create 기능에서 JSON parse error 발생
- 문제의 원인이 엔티티 객체를 그대로 사용한 것일 수 있다고 판단하여,  
`Member`와 `MemberProduct`를 각각 DTO로 분리해 전달하도록 수정했습니다.

하지만 DTO로 바꾼 이후에도 동일한 파싱 오류가 계속 발생하고 있습니다.

- JSON parse error: Cannot construct instance of `com.microservices.demo.practiceserver.domain.member.entity.Member` (although at least one Creator exists): no int/Int-argument constructor/factory method to deserialize from Number value (1)]


- 요청 바디 예시:
```json
{
  "score": 4.5,
  "content": "not bad",
  "member": 1,
  "memberProduct": 12
}
```

## ✅ 기타 참고 사항
- 아직 기능은 미완성이지만 중간 점검 및 피드백을 위해 PR 올립니다.